### PR TITLE
Add "source" field linking to original comment URL

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -342,6 +342,9 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/Reaction'
+                source:
+                    type: string
+                    format: uri
                 children:
                     $ref: '#/components/schemas/CommentsArray'
         MoreComment:


### PR DESCRIPTION
For warblerorg/warbler#2. Link to the original reddit/twitter post URL. The URL can also be used by the client to show an icon representing the source type.